### PR TITLE
Update color changes on overscroll

### DIFF
--- a/dist/overflow-color.cjs.js
+++ b/dist/overflow-color.cjs.js
@@ -56,11 +56,9 @@ var checkScroll = function checkScroll() {
     requestAnimFrame(function () {
       var scrollHeight = document.body.scrollHeight;
       var innerHeight = window.innerHeight;
-      if (scrollHeight === innerHeight) {
-        setBgColor(bottomColor);
-      } else {
-        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
-      }
+
+      setBgColor(innerHeight - scrollHeight + 2 * lastScrollY > 0 ? bottomColor : topColor);
+
       ticking = false;
     });
     ticking = true;

--- a/dist/overflow-color.esm.js
+++ b/dist/overflow-color.esm.js
@@ -54,11 +54,9 @@ var checkScroll = function checkScroll() {
     requestAnimFrame(function () {
       var scrollHeight = document.body.scrollHeight;
       var innerHeight = window.innerHeight;
-      if (scrollHeight === innerHeight) {
-        setBgColor(bottomColor);
-      } else {
-        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
-      }
+
+      setBgColor(innerHeight - scrollHeight + 2 * lastScrollY > 0 ? bottomColor : topColor);
+
       ticking = false;
     });
     ticking = true;

--- a/dist/overflow-color.esm.js
+++ b/dist/overflow-color.esm.js
@@ -55,6 +55,8 @@ var checkScroll = function checkScroll() {
       var scrollHeight = document.body.scrollHeight;
       var innerHeight = window.innerHeight;
 
+      // If we're more than halfway down the page, use the bottom color. Otherwise,
+      // use the top color.
       setBgColor(innerHeight - scrollHeight + 2 * lastScrollY > 0 ? bottomColor : topColor);
 
       ticking = false;

--- a/dist/overflow-color.umd.js
+++ b/dist/overflow-color.umd.js
@@ -26,24 +26,6 @@
   }();
 
   /**
-  * @param {string} style
-  */
-
-  var setStyleTag = (style) => {
-    if (!styleTag) {
-      styleTag = document.createElement('style');
-      var head = document.head || document.getElementsByTagName('head')[0];
-      head.appendChild(styleTag);
-    }
-    
-    if (styleTag.styleSheet) {
-      styleTag.styleSheet.cssText = style;
-    } else {
-      styleTag.innerHTML = style;
-    }
-  }
-
-  /**
    * If needed, set the new new color as
    * html background
    * @param {string} color
@@ -53,19 +35,19 @@
       currentBgColor = color;
       var css = 'html { background: ' + currentBgColor + '; }';
 
-      setStyleTag(css);
+      if (!styleTag) {
+        styleTag = document.createElement('style');
+        var head = document.head || document.getElementsByTagName('head')[0];
+        head.appendChild(styleTag);
+      }
+      
+      if (styleTag.styleSheet) {
+        styleTag.styleSheet.cssText = css;
+      } else {
+        styleTag.innerHTML = css;
+      }
     }
   };
-
-  /**
-   * Split background in two colors on pages without scroll
-   */
-  var splitBgColor = () => {
-    var css = 'html { background: ' + topColor + ';' + 
-    'background: ' + '-webkit-linear-gradient(0deg, ' + topColor + ' 50%, ' + bottomColor + ' 50%);' + 
-    'background: ' + 'linear-gradient(0deg, ' + topColor + ' 50%, ' + bottomColor + ' 50%); }';
-    setStyleTag(css);
-  }
 
   /**
    * Checks the scroll position and determines
@@ -78,11 +60,9 @@
       requestAnimFrame(function () {
         var scrollHeight = document.body.scrollHeight;
         var innerHeight = window.innerHeight;
-        if (innerHeight === scrollHeight) {
-          splitBgColor();
-        } else {
-          setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
-        }
+
+        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY > 0 ? bottomColor : topColor);
+
         ticking = false;
       });
       ticking = true;

--- a/dist/overflow-color.umd.js
+++ b/dist/overflow-color.umd.js
@@ -63,7 +63,7 @@
   var splitBgColor = () => {
     var css = 'html { background: ' + topColor + ';' + 
     'background: ' + '-webkit-linear-gradient(0deg, ' + topColor + ' 50%, ' + bottomColor + ' 50%);' + 
-    'background: ' + 'linear-gradient(0deg, ' + topColor + ' 50%, ' + bottomColor + ' 50%);';
+    'background: ' + 'linear-gradient(0deg, ' + topColor + ' 50%, ' + bottomColor + ' 50%); }';
     setStyleTag(css);
   }
 

--- a/dist/overflow-color.umd.js
+++ b/dist/overflow-color.umd.js
@@ -8,10 +8,7 @@
 
   var topColor = void 0;
   var bottomColor = void 0;
-
   var currentBgColor = void 0;
-  var styleTag = void 0;
-
   var lastScrollY = void 0;
   var ticking = false;
 
@@ -30,6 +27,11 @@
    * html background
    * @param {string} color
    */
+
+  /**
+   * It makes sense to apply background-color to the root element of the page in this way,
+   * because we want it to flood the whole viewport and change it fast on scrolling.
+   */
   var setBgColor = function setBgColor(color) {
     if (currentBgColor !== color) {
       currentBgColor = color;
@@ -40,7 +42,9 @@
   /**
    * Checks the scroll position and determines
    * the overflow color to set between the
-   * topColor and the bottomColor
+   * topColor and the bottomColor.
+   * In order to get rid of the flickers while scrolling up and down too fast on the page without scrolling,
+   * we set appropriate background color as soon as scroll starts moving.
    */
   var checkScroll = function checkScroll() {
     lastScrollY = window.scrollY;
@@ -101,6 +105,12 @@
     if (bodyComputedBackground === '' || bodyComputedStyle.getPropertyValue('background-color') === 'rgba(0, 0, 0, 0)' && bodyComputedBackground.substring(21, 17) === 'none') {
       bodyComputedBackground = 'white';
     }
+
+    /**
+     * This made just for reliability. We set background-color to bottomColor while scrolling down,
+     * and when we don't scroll or there is no scroll at all,
+     * we apply topColor so that each color ends up in the right place.
+     */
 
     var scrollHeight = document.body.scrollHeight;
     var innerHeight = window.innerHeight;

--- a/dist/overflow-color.umd.js
+++ b/dist/overflow-color.umd.js
@@ -33,19 +33,7 @@
   var setBgColor = function setBgColor(color) {
     if (currentBgColor !== color) {
       currentBgColor = color;
-      var css = 'html { background: ' + currentBgColor + '; }';
-
-      if (!styleTag) {
-        styleTag = document.createElement('style');
-        var head = document.head || document.getElementsByTagName('head')[0];
-        head.appendChild(styleTag);
-      }
-
-      if (styleTag.styleSheet) {
-        styleTag.styleSheet.cssText = css;
-      } else {
-        styleTag.innerHTML = css;
-      }
+      document.documentElement.style.backgroundColor = color;
     }
   };
 
@@ -57,14 +45,18 @@
   var checkScroll = function checkScroll() {
     lastScrollY = window.scrollY;
     if (!ticking && (topColor || bottomColor)) {
-      requestAnimFrame(function () {
-        var scrollHeight = document.body.scrollHeight;
-        var innerHeight = window.innerHeight;
-        if (scrollHeight === innerHeight) {
+      var scrollHeight = document.body.scrollHeight;
+      var innerHeight = window.innerHeight;
+
+      requestAnimFrame(() => {
+        if (lastScrollY > 0) {
           setBgColor(bottomColor);
-        } else {
-          setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
         }
+
+        if (innerHeight - scrollHeight + 2 * lastScrollY < 0) {
+          setBgColor(topColor);
+        }
+
         ticking = false;
       });
       ticking = true;
@@ -109,7 +101,13 @@
     if (bodyComputedBackground === '' || bodyComputedStyle.getPropertyValue('background-color') === 'rgba(0, 0, 0, 0)' && bodyComputedBackground.substring(21, 17) === 'none') {
       bodyComputedBackground = 'white';
     }
-    document.body.style.background = 'transparent';
+
+    var scrollHeight = document.body.scrollHeight;
+    var innerHeight = window.innerHeight;
+
+    if (scrollHeight === innerHeight) {
+      setBgColor(topColor);
+    }
 
     checkScroll();
   };

--- a/src/index.js
+++ b/src/index.js
@@ -29,22 +29,10 @@ const requestAnimFrame = (() => {
  * html background
  * @param {string} color
  */
-const setBgColor = color => {
+const setBgColor = (color) => {
   if (currentBgColor !== color) {
     currentBgColor = color;
-    const css = `html { background: ${currentBgColor}; }`;
-
-    if (!styleTag) {
-      styleTag = document.createElement('style');
-      const head = document.head || document.getElementsByTagName('head')[0];
-      head.appendChild(styleTag);
-    }
-
-    if (styleTag.styleSheet) {
-      styleTag.styleSheet.cssText = css;
-    } else {
-      styleTag.innerHTML = css;
-    }
+    document.documentElement.style.backgroundColor = color;
   }
 };
 
@@ -56,14 +44,18 @@ const setBgColor = color => {
 const checkScroll = () => {
   lastScrollY = window.scrollY;
   if (!ticking && (topColor || bottomColor)) {
+    const { scrollHeight } = document.body;
+    const { innerHeight } = window;
+    
     requestAnimFrame(() => {
-      const scrollHeight = document.body.scrollHeight;
-      const innerHeight = window.innerHeight;
-      if (scrollHeight === innerHeight) {
+      if (lastScrollY > 0) {
         setBgColor(bottomColor);
-      } else {
-        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
       }
+
+      if (innerHeight - scrollHeight + 2 * lastScrollY < 0) {
+        setBgColor(topColor);
+      }
+
       ticking = false;
     });
     ticking = true;
@@ -111,8 +103,14 @@ const updateOverflowColor = () => {
   ) {
     bodyComputedBackground = 'white';
   }
-  document.body.style.background = 'transparent';
-
+  
+  const { scrollHeight } = document.body;
+  const { innerHeight } = window;
+  
+  if (scrollHeight === innerHeight) {
+    setBgColor(topColor);
+  }
+  
   checkScroll();
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,11 +59,9 @@ const checkScroll = () => {
     requestAnimFrame(() => {
       const scrollHeight = document.body.scrollHeight;
       const innerHeight = window.innerHeight;
-      if (scrollHeight === innerHeight) {
-        setBgColor(bottomColor);
-      } else {
-        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
-      }
+      
+      setBgColor(innerHeight - scrollHeight + 2 * lastScrollY > 0 ? bottomColor : topColor);
+
       ticking = false;
     });
     ticking = true;

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,22 @@ const requestAnimFrame = (() => {
  * html background
  * @param {string} color
  */
-const setBgColor = (color) => {
+const setBgColor = color => {
   if (currentBgColor !== color) {
     currentBgColor = color;
-    document.documentElement.style.backgroundColor = color;
+    const css = `html { background: ${currentBgColor}; }`;
+
+    if (!styleTag) {
+      styleTag = document.createElement('style');
+      const head = document.head || document.getElementsByTagName('head')[0];
+      head.appendChild(styleTag);
+    }
+
+    if (styleTag.styleSheet) {
+      styleTag.styleSheet.cssText = css;
+    } else {
+      styleTag.innerHTML = css;
+    }
   }
 };
 
@@ -44,18 +56,14 @@ const setBgColor = (color) => {
 const checkScroll = () => {
   lastScrollY = window.scrollY;
   if (!ticking && (topColor || bottomColor)) {
-    const { scrollHeight } = document.body;
-    const { innerHeight } = window;
-    
     requestAnimFrame(() => {
-      if (lastScrollY > 0) {
+      const scrollHeight = document.body.scrollHeight;
+      const innerHeight = window.innerHeight;
+      if (scrollHeight === innerHeight) {
         setBgColor(bottomColor);
+      } else {
+        setBgColor(innerHeight - scrollHeight + 2 * lastScrollY < 0 ? topColor : bottomColor);
       }
-
-      if (innerHeight - scrollHeight + 2 * lastScrollY < 0) {
-        setBgColor(topColor);
-      }
-
       ticking = false;
     });
     ticking = true;
@@ -103,14 +111,8 @@ const updateOverflowColor = () => {
   ) {
     bodyComputedBackground = 'white';
   }
-  
-  const { scrollHeight } = document.body;
-  const { innerHeight } = window;
-  
-  if (scrollHeight === innerHeight) {
-    setBgColor(topColor);
-  }
-  
+  document.body.style.background = 'transparent';
+
   checkScroll();
 };
 


### PR DESCRIPTION
**Update**
I did some research on how things work in this library and how to fix those flickers on fast scrolling. Apparently `min-height: 100%` in styles for the `#root` container doesn't work properly in mobile browsers, on iOS in particular. For example, on Home page there is an empty white space below the page's content, that appears because of the toolbar. That white space makes `background-color` changes visible by flashing of colors on overscrolling. In order to get rid of that useless white space and make color changes to look more natural, it's better to set `height: 100vh` on body, because it makes the whole content of the page fit the viewport. It is related only to mobile browsers though, due to the difference in rendering, so the desktop version stays the same.